### PR TITLE
chore: Sets PriceEngine props argument as optional

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -18,7 +18,7 @@ import type {
  * This is the API Client to interact with our Price Engine API.
  */
 export class PriceEngine extends BaseFetcher {
-  constructor(props: ClientOptions) {
+  constructor(props?: ClientOptions) {
     super(props)
   }
 


### PR DESCRIPTION
Summary
⚙️ Sets `props` argument as optional on `PriceEngine` class' constructor method.

Affected sections
🗃 `src/core.ts`